### PR TITLE
Implemented locale fallback mechanism for the button url

### DIFF
--- a/frontend/components/Button.jsx
+++ b/frontend/components/Button.jsx
@@ -5,18 +5,8 @@ import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { LoadingContext } from '@shopgate/engage/core';
 import { getCurrentRoute } from '@shopgate/pwa-common/helpers/router';
-import appConfig from '@shopgate/pwa-common/helpers/config';
 import { signInWithApple } from '../action-creators';
-
-/**
- * Transforms the app config language to ISO format.
- * @returns {string}
- */
-function getLocale() {
-  const pieces = appConfig.language.split('-');
-  const locale = `${pieces[0]}_${pieces[1].toUpperCase()}`;
-  return locale;
-}
+import { getLocale } from '../helpers';
 
 const button = css({
   border: 0,

--- a/frontend/constants/index.js
+++ b/frontend/constants/index.js
@@ -3,3 +3,45 @@ export const SIGN_IN_WITH_APPLE = 'SIGN_IN_WITH_APPLE';
 export const REQUEST_APPLE_CONFIG = 'REQUEST_APPLE_CONFIG';
 export const REQUEST_APPLE_CONFIG_SUCCESS = 'REQUEST_APPLE_CONFIG_SUCCESS';
 export const REQUEST_APPLE_CONFIG_ERROR = 'REQUEST_APPLE_CONFIG_ERROR';
+
+export const SUPPORTED_BUTTON_LOCALES = [
+  'ar_SA',
+  'ca_ES',
+  'cs_CZ',
+  'da_DK',
+  'de_DE',
+  'el_GR',
+  'en_GB',
+  'en_US',
+  'es_ES',
+  'es_MX',
+  'fi_FI',
+  'fr_CA',
+  'fr_FR',
+  'hr_HR',
+  'hu_HU',
+  'id_ID',
+  'it_IT',
+  'iw_IL',
+  'ja_JP',
+  'ko_KR',
+  'ms_MY',
+  'nl_NL',
+  'no_NO',
+  'pl_PL',
+  'pt_BR',
+  'pt_PT',
+  'ro_RO',
+  'ru_RU',
+  'sk_SK',
+  'sv_SE',
+  'th_TH',
+  'tr_TR',
+  'uk_UA',
+  'vi_VI',
+  'zh_CN',
+  'zh_HK',
+  'zh_TW',
+];
+
+export const DEFAULT_BUTTON_LOCALE = 'en_US';

--- a/frontend/constants/index.js
+++ b/frontend/constants/index.js
@@ -4,6 +4,9 @@ export const REQUEST_APPLE_CONFIG = 'REQUEST_APPLE_CONFIG';
 export const REQUEST_APPLE_CONFIG_SUCCESS = 'REQUEST_APPLE_CONFIG_SUCCESS';
 export const REQUEST_APPLE_CONFIG_ERROR = 'REQUEST_APPLE_CONFIG_ERROR';
 
+/**
+ * @link https://developer.apple.com/documentation/signinwithapplejs/incorporating_sign_in_with_apple_into_other_platforms
+ */
 export const SUPPORTED_BUTTON_LOCALES = [
   'ar_SA',
   'ca_ES',

--- a/frontend/helpers/__tests__/index.spec.js
+++ b/frontend/helpers/__tests__/index.spec.js
@@ -1,0 +1,32 @@
+import { DEFAULT_BUTTON_LOCALE } from '../../constants';
+import { getLocale } from '../index';
+
+const mockAppConfig = {
+  language: null,
+};
+
+jest.mock('@shopgate/pwa-common/helpers/config', () => ({
+  get language() { return mockAppConfig.language; },
+}));
+
+describe('Helpers', () => {
+  describe('getLocale', () => {
+    beforeEach(() => {
+      mockAppConfig.language = 'en-us';
+    });
+
+    it('should return the correct locale for en-us', () => {
+      expect(getLocale()).toBe('en_US');
+    });
+
+    it('should return the a fallback locale for de-ch', () => {
+      mockAppConfig.language = 'de-ch';
+      expect(getLocale()).toBe('de_DE');
+    });
+
+    it('should return the default button locale when no locale can be determined via the supported locales', () => {
+      mockAppConfig.language = 'sw-ke';
+      expect(getLocale()).toBe(DEFAULT_BUTTON_LOCALE);
+    });
+  });
+});

--- a/frontend/helpers/index.js
+++ b/frontend/helpers/index.js
@@ -1,0 +1,21 @@
+import appConfig from '@shopgate/pwa-common/helpers/config';
+import { SUPPORTED_BUTTON_LOCALES, DEFAULT_BUTTON_LOCALE } from '../constants';
+
+/**
+ * Transforms the app config language to ISO format.
+ * @returns {string}
+ */
+export function getLocale() {
+  const [language, region] = appConfig.language.split('-');
+  let locale = `${language}_${region.toUpperCase()}`;
+
+  if (!SUPPORTED_BUTTON_LOCALES.includes(locale)) {
+    locale = SUPPORTED_BUTTON_LOCALES.find(entry => entry.startsWith(language));
+  }
+
+  if (!locale) {
+    locale = DEFAULT_BUTTON_LOCALE;
+  }
+
+  return locale;
+}

--- a/frontend/helpers/index.js
+++ b/frontend/helpers/index.js
@@ -7,14 +7,13 @@ import { SUPPORTED_BUTTON_LOCALES, DEFAULT_BUTTON_LOCALE } from '../constants';
  */
 export function getLocale() {
   const [language, region] = appConfig.language.split('-');
-  let locale = `${language}_${region.toUpperCase()}`;
+  const locale = `${language}_${region.toUpperCase()}`;
 
   if (!SUPPORTED_BUTTON_LOCALES.includes(locale)) {
-    locale = SUPPORTED_BUTTON_LOCALES.find(entry => entry.startsWith(language));
-  }
-
-  if (!locale) {
-    locale = DEFAULT_BUTTON_LOCALE;
+    return (
+      SUPPORTED_BUTTON_LOCALES.find(entry => entry.startsWith(language)) ||
+      DEFAULT_BUTTON_LOCALE
+    );
   }
 
   return locale;


### PR DESCRIPTION
This ticket introduces a fallback mechanism for the `locale` parameter of the "Sign in with Apple" button url. The locale is usually determined via the app language (locale).
When this is set to a locale string that's not supported for the button, we'll now try to find a locale with at least a matching language. If this also doesn't exist, `en_US` will be used.